### PR TITLE
implement stop_archiving_on_duration feature

### DIFF
--- a/lib/archived_remote_object/archive/archived_object.rb
+++ b/lib/archived_remote_object/archive/archived_object.rb
@@ -4,6 +4,7 @@ module ArchivedRemoteObject
   module Archive
     class ArchivedObject
       CantBeRestoredError = Class.new(StandardError)
+      CantStopArchivingOnDurationError = Class.new(StandardError)
 
       def initialize(
         key:,
@@ -32,6 +33,12 @@ module ArchivedRemoteObject
         raise CantBeRestoredError if available? || restore_in_progress?
 
         remote_object.restore
+      end
+
+      def stop_archiving_on_duration
+        raise CantStopArchivingOnDurationError if !restored? || restore_in_progress?
+
+        remote_object.stop_archiving_on_duration
       end
 
       def available?

--- a/lib/archived_remote_object/aws_s3/archived_object.rb
+++ b/lib/archived_remote_object/aws_s3/archived_object.rb
@@ -34,6 +34,10 @@ module ArchivedRemoteObject
         remote_object.restore(key: key, duration: restore_duration_days)
       end
 
+      def stop_archiving_on_duration
+        remote_object.storage_class = 'STANDARD'
+      end
+
       def sync
         tap { remote_object.sync }
       end

--- a/lib/archived_remote_object/aws_s3/client.rb
+++ b/lib/archived_remote_object/aws_s3/client.rb
@@ -33,6 +33,11 @@ module ArchivedRemoteObject
         s3_client.restore_object(bucket: bucket, key: key, restore_request: { days: duration })
       end
 
+      def assign_storage_class(key:, storage_class:)
+        s3_client.stub_responses(:copy_object) if stubbed?
+        s3_client.copy_object(bucket: bucket, key: key, copy_source: "#{bucket}/#{key}", storage_class: storage_class)
+      end
+
       private
 
       def bucket

--- a/lib/archived_remote_object/aws_s3/remote_object.rb
+++ b/lib/archived_remote_object/aws_s3/remote_object.rb
@@ -23,6 +23,11 @@ module ArchivedRemoteObject
         remote_client.restore(**args)
       end
 
+      def storage_class=(storage_class)
+        # accepts STANDARD, STANDARD_IA, ONEZONE_IA, GLACIER, INTELLIGENT_TIERING, DEEP_ARCHIVE
+        remote_client.assign_storage_class(key: key, storage_class: storage_class)
+      end
+
       def sync
         tap { fetch_attributes }
       end

--- a/spec/archive/archived_object_spec.rb
+++ b/spec/archive/archived_object_spec.rb
@@ -144,6 +144,39 @@ describe ArchivedRemoteObject::Archive::ArchivedObject do
     end
   end
 
+  describe "#stop_archiving_on_duration" do
+    context 'when "not restored"' do
+      it "raises error" do
+        expect(archived_object).to receive(:restored?).once.and_return(false)
+        expect(archived_object).not_to receive(:restore_in_progress?)
+        expect(source).not_to receive(:stop_archiving_on_duration)
+        expect { archived_object.stop_archiving_on_duration }
+          .to raise_exception(described_class::CantStopArchivingOnDurationError)
+      end
+    end
+
+    context 'when "restored"' do
+      context 'when "restore_in_progress"' do
+        it "raises error" do
+          expect(archived_object).to receive(:restored?).once.and_return(true)
+          expect(archived_object).to receive(:restore_in_progress?).once.and_return(true)
+          expect(source).not_to receive(:stop_archiving_on_duration)
+          expect { archived_object.stop_archiving_on_duration }
+            .to raise_exception(described_class::CantStopArchivingOnDurationError)
+        end
+      end
+
+      context 'when "restore_in_progress"' do
+        it "fires stop_archiving_on_duration on source" do
+          expect(archived_object).to receive(:restored?).once.and_return(true)
+          expect(archived_object).to receive(:restore_in_progress?).once.and_return(false)
+          expect(source).to receive(:stop_archiving_on_duration).once.with(no_args)
+          archived_object.stop_archiving_on_duration
+        end
+      end
+    end
+  end
+
   describe "#sync" do
     it "fires sync on source" do
       expect(source).to receive(:sync)

--- a/spec/aws_s3/archived_object_spec.rb
+++ b/spec/aws_s3/archived_object_spec.rb
@@ -151,6 +151,13 @@ describe ArchivedRemoteObject::AwsS3::ArchivedObject do
     end
   end
 
+  describe "#stop_archiving_on_duration" do
+    it 'fires storage_class setter request with "STANDARD" storage class on remote_object' do
+      expect(remote_object).to receive(:storage_class=).once.with("STANDARD")
+      archived_object.stop_archiving_on_duration
+    end
+  end
+
   describe "#sync" do
     it "fires sync on remote object" do
       expect(remote_object).to receive(:sync).with(no_args).and_return(remote_object)

--- a/spec/aws_s3/client_spec.rb
+++ b/spec/aws_s3/client_spec.rb
@@ -59,4 +59,32 @@ describe ArchivedRemoteObject::AwsS3::Client do
       end
     end
   end
+
+  describe "#assign_storage_class" do
+    it "fires copy_object request with proper key/copy_source/storage_class" do
+      expect(s3_client)
+        .to receive(:copy_object).once.with(
+          bucket: "bucket",
+          key: "test-object-key",
+          copy_source: "bucket/test-object-key",
+          storage_class: "STANDARD"
+        )
+      client.assign_storage_class(key: "test-object-key", storage_class: "STANDARD")
+    end
+
+    context "with API request" do
+      it "fires external copy_object request and returns copy_object_output response" do
+        restore_object_data = client.assign_storage_class(key: "test-object-key", storage_class: "STANDARD")
+        expect(restore_object_data.data).to be_kind_of(Aws::S3::Types::CopyObjectOutput)
+        expect(restore_object_data.context.operation_name).to eq(:copy_object)
+        expect(restore_object_data.context.params)
+          .to eq(
+            bucket: "bucket",
+            key: "test-object-key",
+            storage_class: "STANDARD",
+            copy_source: "bucket/test-object-key"
+          )
+      end
+    end
+  end
 end

--- a/spec/aws_s3/remote_object_spec.rb
+++ b/spec/aws_s3/remote_object_spec.rb
@@ -24,6 +24,13 @@ describe ArchivedRemoteObject::AwsS3::RemoteObject do
     end
   end
 
+  describe "#storage_class=" do
+    it "fires assign_storage_class on remote_client with proper arguments" do
+      expect(remote_client).to receive(:assign_storage_class).once.with(key: key, storage_class: "STANDARD")
+      remote_object.storage_class = "STANDARD"
+    end
+  end
+
   describe "#sync" do
     it "fires fetch_object_data request to reload archive_data" do
       expect(remote_client).to receive(:fetch_object_data).with(key: key).and_return(archive_data)


### PR DESCRIPTION
The remote-object going back to the archive on the set duration, to stop archiving it we need to change storage-class to standard or any other which is not going to be archived